### PR TITLE
Remove sklearn from dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,5 @@ scikit-learn==0.22.1
 scipy==1.4.1
 seaborn==0.9.0
 six==1.14.0
-sklearn==0.0
 torch==1.4.0
 tqdm==4.41.1


### PR DESCRIPTION
`sklearn` is deprecated, it is recommended to use `scikit-learn`. Also, specified version was super weird